### PR TITLE
Search for stored value in local data

### DIFF
--- a/lib/decorate.js
+++ b/lib/decorate.js
@@ -15,19 +15,20 @@ exports.decorate = function (params, keyPath, componentName) {
     return params
   }
 
-  keyPath = _.toPath(keyPath)
-
   const { data, errors } = this.ctx
-  if (!data) {
-    return ''
-  }
+
+  keyPath = _.toPath(keyPath)
 
   // Strip data from key path as auto store data middleware adds it
   if (keyPath[0] === 'data') {
     keyPath.shift(1)
   }
 
-  const storedValue = _.get(data, keyPath)
+  // Get stored value from session data, else local data
+  const storedValue = _.get(data, keyPath) || _.get(this.ctx, keyPath)
+  if (!storedValue) {
+    return ''
+  }
 
   params.id = (params.id) ? params.id : keyPath.join('-')
   params.name = (params.name) ? params.name : keyPath.map(s => `[${s}]`).join('')


### PR DESCRIPTION
While data for a form may likely exist in session data, it may be the case that data for the item being edited has been saved to local data:

```js
// request.session
data: {
  users: {
    1: {
      name: 'Paul'
    }
  }
},
// response.locals
user: {
  name: 'Paul'
}
```

Currently, it’s not possible to access local data via the decorate function, without saving it to session data first (which would then involve removing it again once it is no longer needed).

This change mains a preference for searching for values in session data, but if no value can be found, does a further search in local data before returning nothing.