### PR TITLE
Defer to an item’s `checked` or `selected` parameter if there is no context data

### DIFF
--- a/lib/decorate.js
+++ b/lib/decorate.js
@@ -107,7 +107,11 @@ export function decorate(params, keyPath, componentName) {
         let checkedValue = ''
         let selectedValue = ''
 
-        if (Array.isArray(storedValue)) {
+        if (storedValue === undefined) {
+          // Stored value undefined, defer to `checked` or `selected` params
+          checkedValue = item.checked
+          selectedValue = item.selected
+        } else if (Array.isArray(storedValue)) {
           // Stored value is an array, check it exists in the array
           if (storedValue.indexOf(item.value) !== -1) {
             checkedValue = 'checked'

--- a/test/fixtures/radios-checked.njk
+++ b/test/fixtures/radios-checked.njk
@@ -1,0 +1,29 @@
+{% from "x-nhsuk/decorated/radios/macro.njk" import radios with context %}
+
+{{ radios({
+  fieldset: {
+    legend: {
+      text: "Where do you live?"
+    }
+  },
+  items: [{
+    value: "england",
+    text: "England",
+    checked: true
+  }, {
+    value: "scotland",
+    text: "Scotland"
+  }, {
+    value: "wales",
+    text: "Wales"
+  }, {
+    value: "northern-ireland",
+    text: "Northern Ireland"
+  }, {
+    divider: "or"
+  }, {
+    value: "other",
+    text: "Another country"
+  }],
+  decorate: "country"
+}) }}

--- a/test/lib/decorate.js
+++ b/test/lib/decorate.js
@@ -100,6 +100,23 @@ test('Decorates form component with items (data stored in array)', () => {
   assert.match(result, /id="country-2".*name="\[country\].*value="scotland"/)
 })
 
+test('Decorates form component with items (no data, no item checked)', () => {
+  const result = env.render('radios.njk')
+
+  assert.match(result, /id="country-1".*name="\[country\].*value="england"/)
+  assert.match(result, /id="country-2".*name="\[country\].*value="scotland"/)
+})
+
+test('Decorates form component with items (no data, item checked)', () => {
+  const result = env.render('radios-checked.njk')
+
+  assert.match(
+    result,
+    /id="country-1".*name="\[country\].*value="england".*checked/
+  )
+  assert.match(result, /id="country-2".*name="\[country\].*value="scotland"/)
+})
+
 test('Decorates button component', () => {
   const result = env.render('button.njk', data)
 


### PR DESCRIPTION
Form components with items have an item checked/selected based on contextual data.

Sometimes there may be no contextual data provided, however one of the items has been marked as checked/selected by other means; the decorate function should not override this, unless there is contextual data to do so with.